### PR TITLE
bpo-18795: Add cumpercall and totalpercall keys to pstats sort_stats

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -402,37 +402,41 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
 
       The following are the valid string and SortKey:
 
-      +------------------+---------------------+----------------------+
-      | Valid String Arg | Valid enum Arg      | Meaning              |
-      +==================+=====================+======================+
-      | ``'calls'``      | SortKey.CALLS       | call count           |
-      +------------------+---------------------+----------------------+
-      | ``'cumulative'`` | SortKey.CUMULATIVE  | cumulative time      |
-      +------------------+---------------------+----------------------+
-      | ``'cumtime'``    | N/A                 | cumulative time      |
-      +------------------+---------------------+----------------------+
-      | ``'file'``       | N/A                 | file name            |
-      +------------------+---------------------+----------------------+
-      | ``'filename'``   | SortKey.FILENAME    | file name            |
-      +------------------+---------------------+----------------------+
-      | ``'module'``     | N/A                 | file name            |
-      +------------------+---------------------+----------------------+
-      | ``'ncalls'``     | N/A                 | call count           |
-      +------------------+---------------------+----------------------+
-      | ``'pcalls'``     | SortKey.PCALLS      | primitive call count |
-      +------------------+---------------------+----------------------+
-      | ``'line'``       | SortKey.LINE        | line number          |
-      +------------------+---------------------+----------------------+
-      | ``'name'``       | SortKey.NAME        | function name        |
-      +------------------+---------------------+----------------------+
-      | ``'nfl'``        | SortKey.NFL         | name/file/line       |
-      +------------------+---------------------+----------------------+
-      | ``'stdname'``    | SortKey.STDNAME     | standard name        |
-      +------------------+---------------------+----------------------+
-      | ``'time'``       | SortKey.TIME        | internal time        |
-      +------------------+---------------------+----------------------+
-      | ``'tottime'``    | N/A                 | internal time        |
-      +------------------+---------------------+----------------------+
+      +--------------------+---------------------+--------------------------+
+      | Valid String Arg   | Valid enum Arg      | Meaning                  |
+      +====================+=====================+==========================+
+      | ``'calls'``        | SortKey.CALLS       | call count               |
+      +--------------------+---------------------+--------------------------+
+      | ``'cumulative'``   | SortKey.CUMULATIVE  | cumulative time          |
+      +--------------------+---------------------+--------------------------+
+      | ``'cumtime'``      | N/A                 | cumulative time          |
+      +--------------------+---------------------+--------------------------+
+      | ``'file'``         | N/A                 | file name                |
+      +--------------------+---------------------+--------------------------+
+      | ``'filename'``     | SortKey.FILENAME    | file name                |
+      +--------------------+---------------------+--------------------------+
+      | ``'module'``       | N/A                 | file name                |
+      +--------------------+---------------------+--------------------------+
+      | ``'ncalls'``       | N/A                 | call count               |
+      +--------------------+---------------------+--------------------------+
+      | ``'pcalls'``       | SortKey.PCALLS      | primitive call count     |
+      +--------------------+---------------------+--------------------------+
+      | ``'line'``         | SortKey.LINE        | line number              |
+      +--------------------+---------------------+--------------------------+
+      | ``'name'``         | SortKey.NAME        | function name            |
+      +--------------------+---------------------+--------------------------+
+      | ``'nfl'``          | SortKey.NFL         | name/file/line           |
+      +--------------------+---------------------+--------------------------+
+      | ``'stdname'``      | SortKey.STDNAME     | standard name            |
+      +--------------------+---------------------+--------------------------+
+      | ``'time'``         | SortKey.TIME        | internal time            |
+      +--------------------+---------------------+--------------------------+
+      | ``'tottime'``      | N/A                 | internal time            |
+      +--------------------+---------------------+--------------------------+
+      | ``'cumpercall'``   | N/A                 | cumulative time per call |
+      +--------------------+---------------------+--------------------------+
+      | ``'totalpercall'`` | N/A                 | total time per call      |
+      +--------------------+---------------------+--------------------------+
 
       Note that all sorts on statistics are in descending order (placing most
       time consuming items first), where as name, file, and line number searches
@@ -455,6 +459,9 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
 
       .. versionadded:: 3.7
          Added the SortKey enum.
+
+      .. versionadded:: 3.11
+         Added the ``cumpercall`` and ``totalpercall`` keys.
 
    .. method:: reverse_order()
 

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -200,19 +200,21 @@ class Stats:
     # list the tuple indices and directions for sorting,
     # along with some printable description
     sort_arg_dict_default = {
-              "calls"     : (((1,-1),              ), "call count"),
-              "ncalls"    : (((1,-1),              ), "call count"),
-              "cumtime"   : (((3,-1),              ), "cumulative time"),
-              "cumulative": (((3,-1),              ), "cumulative time"),
-              "filename"  : (((4, 1),              ), "file name"),
-              "line"      : (((5, 1),              ), "line number"),
-              "module"    : (((4, 1),              ), "file name"),
-              "name"      : (((6, 1),              ), "function name"),
-              "nfl"       : (((6, 1),(4, 1),(5, 1),), "name/file/line"),
-              "pcalls"    : (((0,-1),              ), "primitive call count"),
-              "stdname"   : (((7, 1),              ), "standard name"),
-              "time"      : (((2,-1),              ), "internal time"),
-              "tottime"   : (((2,-1),              ), "internal time"),
+              "calls"       : (((1,-1),              ), "call count"),
+              "ncalls"      : (((1,-1),              ), "call count"),
+              "cumtime"     : (((4,-1),              ), "cumulative time"),
+              "cumulative"  : (((4,-1),              ), "cumulative time"),
+              "filename"    : (((6, 1),              ), "file name"),
+              "line"        : (((7, 1),              ), "line number"),
+              "module"      : (((6, 1),              ), "file name"),
+              "name"        : (((8, 1),              ), "function name"),
+              "nfl"         : (((8, 1),(6, 1),(7, 1),), "name/file/line"),
+              "pcalls"      : (((0,-1),              ), "primitive call count"),
+              "stdname"     : (((9, 1),              ), "standard name"),
+              "time"        : (((2,-1),              ), "internal time"),
+              "tottime"     : (((2,-1),              ), "internal time"),
+              "cumpercall"  : (((5,-1),              ), "cumulative time per call"),
+              "totalpercall": (((3,-1),              ), "total time per call"),
               }
 
     def get_sort_arg_defs(self):
@@ -263,8 +265,18 @@ class Stats:
 
         stats_list = []
         for func, (cc, nc, tt, ct, callers) in self.stats.items():
-            stats_list.append((cc, nc, tt, ct) + func +
-                              (func_std_string(func), func))
+            if nc == 0:
+                npc = 0
+            else:
+                npc = float(tt)/nc
+
+            if cc == 0:
+                cpc = 0
+            else:
+                cpc = float(ct)/cc
+
+            stats_list.append((cc, nc, tt, npc, ct, cpc) + func +
+                               (func_std_string(func), func))
 
         stats_list.sort(key=cmp_to_key(TupleComp(sort_tuple).compare))
 

--- a/Lib/test/test_pstats.py
+++ b/Lib/test/test_pstats.py
@@ -49,7 +49,7 @@ class StatsTestCase(unittest.TestCase):
     def test_sort_stats_string(self):
         for sort_name in ['calls', 'ncalls', 'cumtime', 'cumulative',
                     'filename', 'line', 'module', 'name', 'nfl', 'pcalls',
-                    'stdname', 'time', 'tottime']:
+                    'stdname', 'time', 'tottime', 'cumpercall', 'totalpercall']:
             self.stats.sort_stats(sort_name)
             self.assertEqual(self.stats.sort_type,
                              self.stats.sort_arg_dict_default[sort_name][-1])

--- a/Misc/NEWS.d/next/Library/2022-03-16-00-18-52.bpo-18795.ov0vob.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-16-00-18-52.bpo-18795.ov0vob.rst
@@ -1,0 +1,1 @@
+Added ``cumpercall`` and ``totalpercall`` keys to pstats sort_stats


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
